### PR TITLE
Fix cyclic gx dep 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+serialize/.ipfsconfig

--- a/config.go
+++ b/config.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/mitchellh/go-homedir"
 )
@@ -70,21 +69,6 @@ func Path(configroot, extension string) (string, error) {
 // directory. If the configuration root directory is empty, use the default one
 func Filename(configroot string) (string, error) {
 	return Path(configroot, DefaultConfigFile)
-}
-
-// HumanOutput gets a config value ready for printing
-func HumanOutput(value interface{}) ([]byte, error) {
-	s, ok := value.(string)
-	if ok {
-		return []byte(strings.Trim(s, "\n")), nil
-	}
-	return Marshal(value)
-}
-
-// Marshal configuration with JSON
-func Marshal(value interface{}) ([]byte, error) {
-	// need to prettyprint, hence MarshalIndent, instead of Encoder
-	return json.MarshalIndent(value, "", "  ")
 }
 
 func FromMap(v map[string]interface{}) (*Config, error) {

--- a/serialize/serialize_test.go
+++ b/serialize/serialize_test.go
@@ -1,4 +1,4 @@
-package fsrepo
+package serialize
 
 import (
 	"os"
@@ -17,8 +17,8 @@ func TestConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cfgRead, err := Load(filename)
-	if err != nil {
+	cfgRead := &config.Config{}
+	if err := Load(filename, cfgRead); err != nil {
 		t.Fatal(err)
 	}
 	if cfgWritten.Identity.PeerID != cfgRead.Identity.PeerID {


### PR DESCRIPTION
This dep cycle came into effect when trying to `gx-go link` this gx package. The `serialize` go package wasn't able to get the `ipfs/go-ipfs-config` import rewritten. This resulted in rewritten-vs-unrewritten type errors.

Gx is a lot easier on you if imports, within one gx package, only point lower in the filesystem, never to parent directories or sibling directories.