### PR TITLE
Add Gateway.APICommands for /api allowlists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+serialize/.ipfsconfig

--- a/gateway.go
+++ b/gateway.go
@@ -6,4 +6,5 @@ type Gateway struct {
 	RootRedirect string
 	Writable     bool
 	PathPrefixes []string
+	APICommands  []string
 }

--- a/init.go
+++ b/init.go
@@ -66,6 +66,7 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 				"Access-Control-Allow-Methods": []string{"GET"},
 				"Access-Control-Allow-Headers": []string{"X-Requested-With", "Range"},
 			},
+			APICommands: []string{},
 		},
 		Reprovider: Reprovider{
 			Interval: "12h",


### PR DESCRIPTION
For https://github.com/ipfs/go-ipfs/pull/4595#issuecomment-416738416

No fs-repo migration needed.