### PR TITLE
allow multiple API/Gateway addresses

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -5,6 +5,6 @@ type Addresses struct {
 	Swarm      []string // addresses for the swarm to listen on
 	Announce   []string // swarm addresses to announce to the network
 	NoAnnounce []string // swarm addresses not to announce to the network
-	API        string   // address for the local API (RPC)
-	Gateway    string   // address to listen on for IPFS HTTP object gateway
+	API        Strings  // address for the local API (RPC)
+	Gateway    Strings  // address to listen on for IPFS HTTP object gateway
 }

--- a/init.go
+++ b/init.go
@@ -105,8 +105,8 @@ func addressesConfig() Addresses {
 		},
 		Announce:   []string{},
 		NoAnnounce: []string{},
-		API:        "/ip4/127.0.0.1/tcp/5001",
-		Gateway:    "/ip4/127.0.0.1/tcp/8080",
+		API:        Strings{"/ip4/127.0.0.1/tcp/5001"},
+		Gateway:    Strings{"/ip4/127.0.0.1/tcp/8080"},
 	}
 }
 

--- a/profile.go
+++ b/profile.go
@@ -66,8 +66,8 @@ profile, enables discovery in local networks.`,
 is useful when using the daemon in test environments.`,
 
 		Transform: func(c *Config) error {
-			c.Addresses.API = "/ip4/127.0.0.1/tcp/0"
-			c.Addresses.Gateway = "/ip4/127.0.0.1/tcp/0"
+			c.Addresses.API = Strings{"/ip4/127.0.0.1/tcp/0"}
+			c.Addresses.Gateway = Strings{"/ip4/127.0.0.1/tcp/0"}
 			c.Addresses.Swarm = []string{
 				"/ip4/127.0.0.1/tcp/0",
 			}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"encoding/json"
+)
+
+// Strings is a helper type that (un)marshals a single string to/from a single
+// JSON string and a slice of strings to/from a JSON array of strings.
+type Strings []string
+
+// UnmarshalJSON conforms to the json.Unmarshaler interface.
+func (o *Strings) UnmarshalJSON(data []byte) error {
+	if data[0] == '[' {
+		return json.Unmarshal(data, (*[]string)(o))
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*o = []string{value}
+	return nil
+}
+
+// MarshalJSON conforms to the json.Marshaler interface.
+func (o Strings) MarshalJSON() ([]byte, error) {
+	switch len(o) {
+	case 0:
+		return json.Marshal(nil)
+	case 1:
+		return json.Marshal(o[0])
+	default:
+		return json.Marshal([]string(o))
+	}
+}
+
+var _ json.Unmarshaler = (*Strings)(nil)
+var _ json.Marshaler = (*Strings)(nil)


### PR DESCRIPTION
Alternative to #6 that doesn't require a migration. This is probably a terrible idea.