### PR TITLE
Fix handling of null strings

### DIFF
--- a/types.go
+++ b/types.go
@@ -17,7 +17,11 @@ func (o *Strings) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &value); err != nil {
 		return err
 	}
-	*o = []string{value}
+	if len(value) == 0 {
+		*o = []string{}
+	} else {
+		*o = []string{value}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Of course `null` (what an empty array marshals to) cast to a string, is an empty string. This fix prevents us from e.g. ending up with empty multiaddrs.