### PR TITLE
add an experiment to prefer TLS 1.3 over secio

### DIFF
--- a/experiments.go
+++ b/experiments.go
@@ -7,4 +7,5 @@ type Experiments struct {
 	Libp2pStreamMounting bool
 	P2pHttpProxy         bool
 	QUIC                 bool
+	PreferTLS            bool
 }


### PR DESCRIPTION
After merging, please add a release tag, so I can use this from go-ipfs. (I don't have write access to any of the IPFS repositories).