### PR TITLE
doc: make StrictSignatureVerification a noop

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -9,10 +9,7 @@ type PubsubConfig struct {
 	// by default.
 	DisableSigning bool
 
-	// StrictSignatureVerification enables strict signature verification.
-	// When enabled, unsigned messages will be rejected. Eventually, this
-	// will be made the default and this option will disappear. Once this
-	// happens, networks will either need to completely disable or
-	// completely enable message signing.
+	// StrictSignatureVerification is a noop. When DisableSigning is false,
+	// messages are _always_ verified.
 	StrictSignatureVerification bool
 }


### PR DESCRIPTION
We're enabling it by default. We'll eventually remove this option but I don't want to break `ipfs config ...` invocations until we've transitioned.