### PR TITLE
add a size config for the datastore/ARCCache

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -23,6 +23,7 @@ type Datastore struct {
 
 	HashOnRead      bool
 	BloomFilterSize int
+	ARCCacheSize    int
 }
 
 // DataStorePath returns the default data store path given a configuration root

--- a/init.go
+++ b/init.go
@@ -119,6 +119,7 @@ func DefaultDatastoreConfig() Datastore {
 		StorageGCWatermark: 90, // 90%
 		GCPeriod:           "1h",
 		BloomFilterSize:    0,
+		ARCCacheSize:       64 << 10,
 		Spec: map[string]interface{}{
 			"type": "mount",
 			"mounts": []interface{}{


### PR DESCRIPTION
This PR add a configuration option to change the size or disable the ARC cache in the datastore.

See https://github.com/ipfs/go-ipfs/issues/6556#issuecomment-521814663 for details.