### PR TITLE
plugins: don't omit empty config values

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -1,11 +1,11 @@
 package config
 
 type Plugins struct {
-	Plugins map[string]Plugin `json:",omitempty"`
+	Plugins map[string]Plugin
 	// TODO: Loader Path? Leaving that out for now due to security concerns.
 }
 
 type Plugin struct {
-	Disabled bool        `json:",omitempty"`
-	Config   interface{} `json:",omitempty"`
+	Disabled bool
+	Config   interface{}
 }


### PR DESCRIPTION
Turns out the go-ipfs config logic really doesn't play well with this. Let's just keep them and avoid encoding empty values another way.