### PR TITLE
profile: badger profile now defaults to asynchronous writes

### DIFF
--- a/profile.go
+++ b/profile.go
@@ -130,7 +130,7 @@ Make sure to backup your data frequently.`,
 				"child": map[string]interface{}{
 					"type":       "badgerds",
 					"path":       "badgerds",
-					"syncWrites": true,
+					"syncWrites": false,
 					"truncate":   true,
 				},
 			}


### PR DESCRIPTION
Per https://github.com/ipfs/go-ipfs/issues/6775 this turns off sync writes in badger by default