### PR TITLE
feat: remove strict signing pubsub option.

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -8,11 +8,4 @@ type PubsubConfig struct {
 	// DisableSigning disables message signing. Message signing is *enabled*
 	// by default.
 	DisableSigning bool
-
-	// StrictSignatureVerification enables strict signature verification.
-	// When enabled, unsigned messages will be rejected. Eventually, this
-	// will be made the default and this option will disappear. Once this
-	// happens, networks will either need to completely disable or
-	// completely enable message signing.
-	StrictSignatureVerification bool
 }


### PR DESCRIPTION
It's still possible to disable signing. However, it's no longer possible to enable signing _and_ disable strict signature verification.