### PR TITLE
default config: add QUIC listening ports + quic to mars.i.ipfs.io

### DIFF
--- a/bootstrap_peers.go
+++ b/bootstrap_peers.go
@@ -19,7 +19,8 @@ var DefaultBootstrapAddresses = []string{
 	"/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
 	"/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
 	"/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
-	"/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ", // mars.i.ipfs.io
+	"/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",       // mars.i.ipfs.io
+	"/ip4/104.131.131.82/quic/4001/quic/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ", // mars.i.ipfs.io
 }
 
 // ErrInvalidPeerAddr signals an address is not a valid peer address.

--- a/init.go
+++ b/init.go
@@ -107,8 +107,9 @@ func addressesConfig() Addresses {
 	return Addresses{
 		Swarm: []string{
 			"/ip4/0.0.0.0/tcp/4001",
-			// "/ip4/0.0.0.0/udp/4002/utp", // disabled for now.
 			"/ip6/::/tcp/4001",
+			"/ip4/0.0.0.0/udp/4001/quic",
+			"/ip6/::/udp/4001/quic",
 		},
 		Announce:   []string{},
 		NoAnnounce: []string{},


### PR DESCRIPTION
fixes 1) of https://github.com/ipfs/go-ipfs/issues/7343