### PR TITLE
feat: add an option for security transport experiments

### DIFF
--- a/experiments.go
+++ b/experiments.go
@@ -8,4 +8,11 @@ type Experiments struct {
 	Libp2pStreamMounting bool
 	P2pHttpProxy         bool
 	StrategicProviding   bool
+
+	// OverrideSecurityTransports overrides the set of available security
+	// transports when non-empty. This option should eventually migrate some
+	// place more stable.
+	//
+	// Default: ["tls", "secio", "noise"].
+	OverrideSecurityTransports []string `json:",omitempty"`
 }


### PR DESCRIPTION
We should have a more permanent way to configure security transports, but experimental flags are a quick and unstable way to do this without making any promises.