### PR TITLE
feat: gateway redirect to another domain

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -18,6 +18,10 @@ type GatewaySpec struct {
 	// NoDNSLink configures this gateway to _not_ resolve DNSLink for the FQDN
 	// provided in `Host` HTTP header.
 	NoDNSLink bool
+
+	// RedirectHost if set configure this gateway to redirect to another
+	// host (domain+port) as CID style when accessing a path style gateway
+	RedirectHost string
 }
 
 // Gateway contains options for the HTTP gateway server.

--- a/gateway.go
+++ b/gateway.go
@@ -20,7 +20,7 @@ type GatewaySpec struct {
 	NoDNSLink bool
 
 	// RedirectHost if set configure this gateway to redirect to another
-	// host (domain+port) as CID style when accessing a path style gateway
+	// host (domain + optional port)
 	RedirectHost string
 }
 


### PR DESCRIPTION
This PR add the config field needed to implement the gateway redirection (path to CID style) to another domain.

Benefits include following the recommended practice of hosting the CID style gateway on another domain to get a strong Origin isolation. Additionally it allow us (Infura) to migrate our traffic out of `infura.io` in one painless step at the same time.

cc @lidel 