### PR TITLE
Add config for downloading repo migrations

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Pubsub    PubsubConfig
 	Peering   Peering
 	DNS       DNS
+	Migration Migration
 
 	Provider     Provider
 	Reprovider   Reprovider

--- a/init.go
+++ b/init.go
@@ -93,8 +93,8 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 			Resolvers: map[string]string{},
 		},
 		Migration: Migration{
-			DownloadSources: DefaultMigrationDownloadSources,
-			Keep:            DefaultMigrationKeep,
+			DownloadSources: []string{},
+			Keep:            "",
 		},
 	}
 

--- a/init.go
+++ b/init.go
@@ -92,6 +92,10 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 		DNS: DNS{
 			Resolvers: map[string]string{},
 		},
+		Migration: Migration{
+			DownloadSources: DefaultMigrationDownloadSources,
+			Keep:            DefaultMigrationKeep,
+		},
 	}
 
 	return conf, nil

--- a/migration.go
+++ b/migration.go
@@ -1,0 +1,22 @@
+package config
+
+import "github.com/libp2p/go-libp2p-core/peer"
+
+const DefaultMigrationKeep = "cache"
+
+var DefaultMigrationDownloadSources = []string{"HTTPS", "IPFS"}
+
+// Migration configures how migrations are downloaded and if the downloads are
+// added to IPFS locally
+type Migration struct {
+	// Sources in order of preference where "HTTPS" means our gateways and
+	// "IPFS" means over IPFS. Any other values are interpretes as hostnames
+	// for custom gateways. An empty list means "do the default thing"
+	DownloadSources []string
+	// Whether or not to keep the migration after downloading it.
+	// Options are "discard", "cache", "pin".  Empty string for default.
+	Keep string
+	// Peers lists the nodes to attempt to connect with when downloading
+	// migrations.
+	Peers []peer.AddrInfo
+}

--- a/migration.go
+++ b/migration.go
@@ -9,9 +9,9 @@ var DefaultMigrationDownloadSources = []string{"HTTPS", "IPFS"}
 // Migration configures how migrations are downloaded and if the downloads are
 // added to IPFS locally
 type Migration struct {
-	// Sources in order of preference where "HTTPS" means our gateways and
-	// "IPFS" means over IPFS. Any other values are interpretes as hostnames
-	// for custom gateways. An empty list means "do the default thing"
+	// Sources in order of preference, where "IPFS" means use IPFS and "HTTPS"
+	// means use default gateways. Any other values are interpreted as
+	// hostnames for custom gateways. Empty list means "use default sources".
 	DownloadSources []string
 	// Whether or not to keep the migration after downloading it.
 	// Options are "discard", "cache", "pin".  Empty string for default.

--- a/migration.go
+++ b/migration.go
@@ -1,7 +1,5 @@
 package config
 
-import "github.com/libp2p/go-libp2p-core/peer"
-
 const DefaultMigrationKeep = "cache"
 
 var DefaultMigrationDownloadSources = []string{"HTTPS", "IPFS"}
@@ -16,7 +14,4 @@ type Migration struct {
 	// Whether or not to keep the migration after downloading it.
 	// Options are "discard", "cache", "pin".  Empty string for default.
 	Keep string
-	// Peers lists the nodes to attempt to connect with when downloading
-	// migrations.
-	Peers []peer.AddrInfo
 }

--- a/migration_test.go
+++ b/migration_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMigrationDecode(t *testing.T) {
+	str := `
+		{
+			"DownloadSources": ["IPFS", "HTTP", "127.0.0.1"],
+			"Keep": "cache",
+			"Peers": [
+				{
+					"ID": "12D3KooWGC6TvWhfapngX6wvJHMYvKpDMXPb3ZnCZ6dMoaMtimQ5",
+					"Addrs": ["/ip4/127.0.0.1/tcp/4001", "/ip4/127.0.0.1/udp/4001/quic"]
+				},
+				{
+					"ID": "12D3KooWGC6TvWhfajpgX6wvJHMYvKpDMXPb3ZnCZ6dMoaMtimQ7",
+					"Addrs": ["/ip4/10.0.0.2/tcp/4001"]
+				}
+			]
+		}
+	`
+
+	var cfg Migration
+	if err := json.Unmarshal([]byte(str), &cfg); err != nil {
+		t.Errorf("failed while unmarshalling migration struct: %s", err)
+	}
+
+	if len(cfg.DownloadSources) != 3 {
+		t.Fatal("wrong number of DownloadSources")
+	}
+	expect := []string{"IPFS", "HTTP", "127.0.0.1"}
+	for i := range expect {
+		if cfg.DownloadSources[i] != expect[i] {
+			t.Errorf("wrong DownloadSource at %d", i)
+		}
+	}
+
+	if cfg.Keep != "cache" {
+		t.Error("wrong value for Keep")
+	}
+
+	if len(cfg.Peers) != 2 {
+		t.Fatal("wrong number of peers")
+	}
+
+	peer := cfg.Peers[0]
+	if peer.ID.String() != "12D3KooWGC6TvWhfapngX6wvJHMYvKpDMXPb3ZnCZ6dMoaMtimQ5" {
+		t.Errorf("wrong ID for first peer")
+	}
+	if len(peer.Addrs) != 2 {
+		t.Error("wrong number of addrs for first peer")
+	}
+	if peer.Addrs[0].String() != "/ip4/127.0.0.1/tcp/4001" {
+		t.Error("wrong first addr for first peer")
+	}
+	if peer.Addrs[1].String() != "/ip4/127.0.0.1/udp/4001/quic" {
+		t.Error("wrong second addr for first peer")
+	}
+
+	peer = cfg.Peers[1]
+	if len(peer.Addrs) != 1 {
+		t.Fatal("wrong number of addrs for second peer")
+	}
+	if peer.Addrs[0].String() != "/ip4/10.0.0.2/tcp/4001" {
+		t.Error("wrong first addr for second peer")
+	}
+}

--- a/migration_test.go
+++ b/migration_test.go
@@ -9,17 +9,7 @@ func TestMigrationDecode(t *testing.T) {
 	str := `
 		{
 			"DownloadSources": ["IPFS", "HTTP", "127.0.0.1"],
-			"Keep": "cache",
-			"Peers": [
-				{
-					"ID": "12D3KooWGC6TvWhfapngX6wvJHMYvKpDMXPb3ZnCZ6dMoaMtimQ5",
-					"Addrs": ["/ip4/127.0.0.1/tcp/4001", "/ip4/127.0.0.1/udp/4001/quic"]
-				},
-				{
-					"ID": "12D3KooWGC6TvWhfajpgX6wvJHMYvKpDMXPb3ZnCZ6dMoaMtimQ7",
-					"Addrs": ["/ip4/10.0.0.2/tcp/4001"]
-				}
-			]
+			"Keep": "cache"
 		}
 	`
 
@@ -40,31 +30,5 @@ func TestMigrationDecode(t *testing.T) {
 
 	if cfg.Keep != "cache" {
 		t.Error("wrong value for Keep")
-	}
-
-	if len(cfg.Peers) != 2 {
-		t.Fatal("wrong number of peers")
-	}
-
-	peer := cfg.Peers[0]
-	if peer.ID.String() != "12D3KooWGC6TvWhfapngX6wvJHMYvKpDMXPb3ZnCZ6dMoaMtimQ5" {
-		t.Errorf("wrong ID for first peer")
-	}
-	if len(peer.Addrs) != 2 {
-		t.Error("wrong number of addrs for first peer")
-	}
-	if peer.Addrs[0].String() != "/ip4/127.0.0.1/tcp/4001" {
-		t.Error("wrong first addr for first peer")
-	}
-	if peer.Addrs[1].String() != "/ip4/127.0.0.1/udp/4001/quic" {
-		t.Error("wrong second addr for first peer")
-	}
-
-	peer = cfg.Peers[1]
-	if len(peer.Addrs) != 1 {
-		t.Fatal("wrong number of addrs for second peer")
-	}
-	if peer.Addrs[0].String() != "/ip4/10.0.0.2/tcp/4001" {
-		t.Error("wrong first addr for second peer")
 	}
 }


### PR DESCRIPTION
Adds a configuration section `Migration` to configure how to download repo migrations and whether or not to keep them.
