### PR TITLE
Add internal knobs for Bitswap tuning

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	Experimental Experiments
 	Plugins      Plugins
 	Pinning      Pinning
+
+	Internal Internal // experimental/unstable options
 }
 
 const (

--- a/internal.go
+++ b/internal.go
@@ -1,0 +1,12 @@
+package config
+
+type Internal struct {
+	Bitswap *InternalBitswap `json:",omitempty"` // This is omitempty since we are expecting to make changes to all subcomponents of Internal
+}
+
+type InternalBitswap struct {
+	TaskWorkerCount             OptionalInteger
+	EngineBlockstoreWorkerCount OptionalInteger
+	EngineTaskWorkerCount       OptionalInteger
+	MaxOutstandingBytesPerPeer  OptionalInteger
+}

--- a/types.go
+++ b/types.go
@@ -208,8 +208,8 @@ func (p Priority) String() string {
 	}
 }
 
-var _ json.Unmarshaler = (*Flag)(nil)
-var _ json.Marshaler = (*Flag)(nil)
+var _ json.Unmarshaler = (*Priority)(nil)
+var _ json.Marshaler = (*Priority)(nil)
 
 // Duration wraps time.Duration to provide json serialization and deserialization.
 //

--- a/types.go
+++ b/types.go
@@ -232,3 +232,55 @@ func (d Duration) String() string {
 
 var _ encoding.TextUnmarshaler = (*Duration)(nil)
 var _ encoding.TextMarshaler = (*Duration)(nil)
+
+// OptionalInteger represents an integer that has a default value
+//
+// When encoded in json, Default is encoded as "null"
+type OptionalInteger struct {
+	value *int64
+}
+
+// WithDefault resolves the integer with the given default.
+func (p OptionalInteger) WithDefault(defaultValue int64) (value int64) {
+	if p.value == nil {
+		return defaultValue
+	}
+	return *p.value
+}
+
+// IsDefault returns if this is a default optional integer
+func (p OptionalInteger) IsDefault() bool {
+	return p.value == nil
+}
+
+func (p OptionalInteger) MarshalJSON() ([]byte, error) {
+	if p.value != nil {
+		return json.Marshal(p.value)
+	}
+	return json.Marshal(nil)
+}
+
+func (p *OptionalInteger) UnmarshalJSON(input []byte) error {
+	switch string(input) {
+	case "null", "undefined":
+		*p = OptionalInteger{}
+	default:
+		var value int64
+		err := json.Unmarshal(input, &value)
+		if err != nil {
+			return err
+		}
+		*p = OptionalInteger{value: &value}
+	}
+	return nil
+}
+
+func (p OptionalInteger) String() string {
+	if p.value == nil {
+		return "default"
+	}
+	return fmt.Sprintf("%d", p.value)
+}
+
+var _ json.Unmarshaler = (*OptionalInteger)(nil)
+var _ json.Marshaler = (*OptionalInteger)(nil)


### PR DESCRIPTION
Adding:
* Internal.Bitswap.EngineBlockstoreWorkerCount
* Internal.Bitswap.TaskWorkerCount
* Internal.Bitswap.EngineTaskWorkerCount
* Internal.Bitswap.MaxOutstandingBytesPerPeer

Part of https://github.com/ipfs/go-ipfs/issues/8233

Includes #142