### PR TITLE
feat: Swarm.RelayService (circuit v2)

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -1,8 +1,10 @@
 package config
 
 type Internal struct {
-	Bitswap                     *InternalBitswap `json:",omitempty"` // This is omitempty since we are expecting to make changes to all subcomponents of Internal
+	// All marked as omitempty since we are expecting to make changes to all subcomponents of Internal
+	Bitswap                     *InternalBitswap `json:",omitempty"`
 	UnixFSShardingSizeThreshold *OptionalString  `json:",omitempty"`
+	Libp2pForceReachability     *OptionalString  `json:",omitempty"`
 }
 
 type InternalBitswap struct {

--- a/profile.go
+++ b/profile.go
@@ -179,6 +179,7 @@ fetching may be degraded.
 			c.Swarm.ConnMgr.LowWater = 20
 			c.Swarm.ConnMgr.HighWater = 40
 			c.Swarm.ConnMgr.GracePeriod = time.Minute.String()
+			c.Swarm.RelayService.Enabled = False
 			return nil
 		},
 	},

--- a/profile.go
+++ b/profile.go
@@ -179,7 +179,6 @@ fetching may be degraded.
 			c.Swarm.ConnMgr.LowWater = 20
 			c.Swarm.ConnMgr.HighWater = 40
 			c.Swarm.ConnMgr.GracePeriod = time.Minute.String()
-			c.Swarm.RelayService.Enabled = False
 			return nil
 		},
 	},

--- a/swarm.go
+++ b/swarm.go
@@ -22,6 +22,8 @@ type SwarmConfig struct {
 	// DisableRelayService disables the limited relay (circuit v2 relay).
 	DisableRelayService bool
 
+	RelayServiceOpts RelayResources
+
 	// EnableAutoRelay enables the "auto relay" feature.
 	//
 	// When both EnableAutoRelay and EnableRelayHop are set, this go-ipfs node
@@ -35,6 +37,38 @@ type SwarmConfig struct {
 
 	// ConnMgr configures the connection manager.
 	ConnMgr ConnMgr
+}
+
+// RelayResources configures the resources of the relay.
+// For any value set to 0, a reasonable default will be used.
+type RelayResources struct {
+	// Limit is the (optional) relayed connection limits.
+	Limit RelayLimit
+
+	// ReservationTTL is the duration of a new (or refreshed reservation).
+	ReservationTTL Duration
+
+	// MaxReservations is the maximum number of active relay slots.
+	MaxReservations int
+	// MaxCircuits is the maximum number of open relay connections for each peer; defaults to 16.
+	MaxCircuits int
+	// BufferSize is the size of the relayed connection buffers.
+	BufferSize int
+
+	// MaxReservationsPerPeer is the maximum number of reservations originating from the same peer.
+	MaxReservationsPerPeer int
+	// MaxReservationsPerIP is the maximum number of reservations originating from the same IP address.
+	MaxReservationsPerIP int
+	// MaxReservationsPerASN is the maximum number of reservations origination from the same ASN.
+	MaxReservationsPerASN int
+}
+
+// RelayLimit are the per relayed connection resource limits.
+type RelayLimit struct {
+	// Duration is the time limit before resetting a relayed connection.
+	Duration Duration
+	// Data is the limit of data relayed (on each direction) before resetting the connection.
+	Data int64
 }
 
 type Transports struct {

--- a/swarm.go
+++ b/swarm.go
@@ -19,10 +19,6 @@ type SwarmConfig struct {
 	// `Transports.Relay` if specified.
 	DisableRelay bool `json:",omitempty"`
 
-	// EnableRelayHop makes this node act as a public relay, relaying
-	// traffic between other nodes.
-	EnableRelayHop bool
-
 	// EnableAutoRelay enables the "auto relay" feature.
 	//
 	// When both EnableAutoRelay and EnableRelayHop are set, this go-ipfs node

--- a/swarm.go
+++ b/swarm.go
@@ -19,6 +19,9 @@ type SwarmConfig struct {
 	// `Transports.Relay` if specified.
 	DisableRelay bool `json:",omitempty"`
 
+	// DisableRelayService disables the limited relay (circuit v2 relay).
+	DisableRelayService bool
+
 	// EnableAutoRelay enables the "auto relay" feature.
 	//
 	// When both EnableAutoRelay and EnableRelayHop are set, this go-ipfs node

--- a/swarm.go
+++ b/swarm.go
@@ -40,27 +40,27 @@ type SwarmConfig struct {
 // For every field a reasonable default will be defined in go-ipfs.
 type RelayService struct {
 	// Enables the limited relay (circuit v2 relay).
-	Enabled Flag
+	Enabled *Flag `json:",omitempty"`
 
 	// Limit is the (optional) relayed connection limits.
-	Limit RelayLimit
+	Limit *RelayLimit `json:",omitempty"`
 
 	// ReservationTTL is the duration of a new (or refreshed reservation).
 	ReservationTTL *OptionalDuration `json:",omitempty"`
 
 	// MaxReservations is the maximum number of active relay slots.
-	MaxReservations OptionalInteger
+	MaxReservations *OptionalInteger `json:",omitempty"`
 	// MaxCircuits is the maximum number of open relay connections for each peer; defaults to 16.
-	MaxCircuits OptionalInteger
+	MaxCircuits *OptionalInteger `json:",omitempty"`
 	// BufferSize is the size of the relayed connection buffers.
-	BufferSize OptionalInteger
+	BufferSize *OptionalInteger `json:",omitempty"`
 
 	// MaxReservationsPerPeer is the maximum number of reservations originating from the same peer.
-	MaxReservationsPerPeer OptionalInteger
+	MaxReservationsPerPeer *OptionalInteger `json:",omitempty"`
 	// MaxReservationsPerIP is the maximum number of reservations originating from the same IP address.
-	MaxReservationsPerIP OptionalInteger
+	MaxReservationsPerIP *OptionalInteger `json:",omitempty"`
 	// MaxReservationsPerASN is the maximum number of reservations origination from the same ASN.
-	MaxReservationsPerASN OptionalInteger
+	MaxReservationsPerASN *OptionalInteger `json:",omitempty"`
 }
 
 // RelayLimit are the per relayed connection resource limits.
@@ -68,7 +68,7 @@ type RelayLimit struct {
 	// Duration is the time limit before resetting a relayed connection.
 	Duration *OptionalDuration `json:",omitempty"`
 	// Data is the limit of data relayed (on each direction) before resetting the connection.
-	Data OptionalInteger
+	Data *OptionalInteger `json:",omitempty"`
 }
 
 type Transports struct {

--- a/swarm.go
+++ b/swarm.go
@@ -42,8 +42,10 @@ type RelayService struct {
 	// Enables the limited relay (circuit v2 relay).
 	Enabled Flag `json:",omitempty"`
 
-	// Limit is the (optional) relayed connection limits.
-	Limit *RelayLimit `json:",omitempty"`
+	// ConnectionDurationLimit is the time limit before resetting a relayed connection.
+	ConnectionDurationLimit *OptionalDuration `json:",omitempty"`
+	// ConnectionDataLimit is the limit of data relayed (on each direction) before resetting the connection.
+	ConnectionDataLimit *OptionalInteger `json:",omitempty"`
 
 	// ReservationTTL is the duration of a new (or refreshed reservation).
 	ReservationTTL *OptionalDuration `json:",omitempty"`
@@ -61,14 +63,6 @@ type RelayService struct {
 	MaxReservationsPerIP *OptionalInteger `json:",omitempty"`
 	// MaxReservationsPerASN is the maximum number of reservations origination from the same ASN.
 	MaxReservationsPerASN *OptionalInteger `json:",omitempty"`
-}
-
-// RelayLimit are the per relayed connection resource limits.
-type RelayLimit struct {
-	// Duration is the time limit before resetting a relayed connection.
-	Duration *OptionalDuration `json:",omitempty"`
-	// Data is the limit of data relayed (on each direction) before resetting the connection.
-	Data *OptionalInteger `json:",omitempty"`
 }
 
 type Transports struct {

--- a/swarm.go
+++ b/swarm.go
@@ -19,14 +19,11 @@ type SwarmConfig struct {
 	// `Transports.Relay` if specified.
 	DisableRelay bool `json:",omitempty"`
 
-	// DisableRelayService disables the limited relay (circuit v2 relay).
-	DisableRelayService bool
-
-	RelayServiceOpts RelayResources
+	RelayService RelayService
 
 	// EnableAutoRelay enables the "auto relay" feature.
 	//
-	// When both EnableAutoRelay and EnableRelayHop are set, this go-ipfs node
+	// When both EnableAutoRelay and RelayService.Enabled are set, this go-ipfs node
 	// will advertise itself as a public relay. Otherwise it will find and use
 	// advertised public relays when it determines that it's not reachable
 	// from the public internet.
@@ -39,9 +36,12 @@ type SwarmConfig struct {
 	ConnMgr ConnMgr
 }
 
-// RelayResources configures the resources of the relay.
-// For any value set to 0, a reasonable default will be used.
-type RelayResources struct {
+// RelayService configures the resources of the circuit v2 relay.
+// For every field a reasonable default will be defined in go-ipfs.
+type RelayService struct {
+	// Enables the limited relay (circuit v2 relay).
+	Enabled Flag
+
 	// Limit is the (optional) relayed connection limits.
 	Limit RelayLimit
 
@@ -49,18 +49,18 @@ type RelayResources struct {
 	ReservationTTL Duration
 
 	// MaxReservations is the maximum number of active relay slots.
-	MaxReservations int
+	MaxReservations OptionalInteger
 	// MaxCircuits is the maximum number of open relay connections for each peer; defaults to 16.
-	MaxCircuits int
+	MaxCircuits OptionalInteger
 	// BufferSize is the size of the relayed connection buffers.
-	BufferSize int
+	BufferSize OptionalInteger
 
 	// MaxReservationsPerPeer is the maximum number of reservations originating from the same peer.
-	MaxReservationsPerPeer int
+	MaxReservationsPerPeer OptionalInteger
 	// MaxReservationsPerIP is the maximum number of reservations originating from the same IP address.
-	MaxReservationsPerIP int
+	MaxReservationsPerIP OptionalInteger
 	// MaxReservationsPerASN is the maximum number of reservations origination from the same ASN.
-	MaxReservationsPerASN int
+	MaxReservationsPerASN OptionalInteger
 }
 
 // RelayLimit are the per relayed connection resource limits.
@@ -68,7 +68,7 @@ type RelayLimit struct {
 	// Duration is the time limit before resetting a relayed connection.
 	Duration Duration
 	// Data is the limit of data relayed (on each direction) before resetting the connection.
-	Data int64
+	Data OptionalInteger
 }
 
 type Transports struct {

--- a/swarm.go
+++ b/swarm.go
@@ -40,7 +40,7 @@ type SwarmConfig struct {
 // For every field a reasonable default will be defined in go-ipfs.
 type RelayService struct {
 	// Enables the limited relay (circuit v2 relay).
-	Enabled *Flag `json:",omitempty"`
+	Enabled Flag `json:",omitempty"`
 
 	// Limit is the (optional) relayed connection limits.
 	Limit *RelayLimit `json:",omitempty"`

--- a/swarm.go
+++ b/swarm.go
@@ -16,18 +16,17 @@ type SwarmConfig struct {
 	// DisableRelay explicitly disables the relay transport.
 	//
 	// Deprecated: This flag is deprecated and is overridden by
-	// `Transports.Relay` if specified.
+	// `Swarm.Transports.Relay` if specified.
 	DisableRelay bool `json:",omitempty"`
 
-	RelayService RelayService
-
-	// EnableAutoRelay enables the "auto relay" feature.
-	//
-	// When both EnableAutoRelay and RelayService.Enabled are set, this go-ipfs node
-	// will advertise itself as a public relay. Otherwise it will find and use
-	// advertised public relays when it determines that it's not reachable
-	// from the public internet.
+	// EnableAutoRelay enables the "auto relay user" feature.
+	// Node will find and use advertised public relays when it determines that
+	// it's not reachable from the public internet.
 	EnableAutoRelay bool
+
+	// RelayService.* controls the "auto relay service" feature.
+	// When enabled, node will provide a limited relay service to other peers.
+	RelayService RelayService
 
 	// Transports contains flags to enable/disable libp2p transports.
 	Transports Transports

--- a/swarm.go
+++ b/swarm.go
@@ -46,7 +46,7 @@ type RelayService struct {
 	Limit RelayLimit
 
 	// ReservationTTL is the duration of a new (or refreshed reservation).
-	ReservationTTL Duration
+	ReservationTTL *OptionalDuration `json:",omitempty"`
 
 	// MaxReservations is the maximum number of active relay slots.
 	MaxReservations OptionalInteger
@@ -66,7 +66,7 @@ type RelayService struct {
 // RelayLimit are the per relayed connection resource limits.
 type RelayLimit struct {
 	// Duration is the time limit before resetting a relayed connection.
-	Duration Duration
+	Duration *OptionalDuration `json:",omitempty"`
 	// Data is the limit of data relayed (on each direction) before resetting the connection.
 	Data OptionalInteger
 }

--- a/types.go
+++ b/types.go
@@ -270,16 +270,16 @@ type OptionalInteger struct {
 }
 
 // WithDefault resolves the integer with the given default.
-func (p OptionalInteger) WithDefault(defaultValue int64) (value int64) {
-	if p.value == nil {
+func (p *OptionalInteger) WithDefault(defaultValue int64) (value int64) {
+	if p == nil || p.value == nil {
 		return defaultValue
 	}
 	return *p.value
 }
 
 // IsDefault returns if this is a default optional integer
-func (p OptionalInteger) IsDefault() bool {
-	return p.value == nil
+func (p *OptionalInteger) IsDefault() bool {
+	return p == nil || p.value == nil
 }
 
 func (p OptionalInteger) MarshalJSON() ([]byte, error) {

--- a/types_test.go
+++ b/types_test.go
@@ -375,6 +375,7 @@ func TestOptionalInteger(t *testing.T) {
 		}
 	}
 
+	// marshal with omitempty
 	type Foo struct {
 		I *OptionalInteger `json:",omitempty"`
 	}
@@ -386,6 +387,20 @@ func TestOptionalInteger(t *testing.T) {
 	if string(out) != expected {
 		t.Fatal("expected omitempty to omit the optional integer")
 	}
+
+	// unmarshal from omitempty output and get default value
+	var foo2 Foo
+	if err := json.Unmarshal(out, &foo2); err != nil {
+		t.Fatalf("%s failed to unmarshall with %s", string(out), err)
+	}
+	if i := foo2.I.WithDefault(42); i != 42 {
+		t.Fatalf("expected default value to be used, got %d", i)
+	}
+	if !foo2.I.IsDefault() {
+		t.Fatal("expected value to be the default")
+	}
+
+	// test invalid values
 	for _, invalid := range []string{
 		"foo", "-1.1", "1.1", "0.0", "[]",
 	} {


### PR DESCRIPTION
- Need this for https://github.com/ipfs/go-ipfs/pull/8522
- circuit v2: https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md

@vyzo How should we expose configuration options for the limited relay? Should we have a `RelayConfig` that mirrors https://github.com/libp2p/go-libp2p/blob/4f129401a3e4828eaec6818e5a2a1a8f9db1bd8c/p2p/protocol/circuitv2/relay/resources.go#L7-L41?