### PR TITLE
add a flag to enable the hole punching service

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -36,7 +36,7 @@ type SwarmConfig struct {
 	RelayService RelayService
 
 	// EnableHolePunching enables the hole punching service.
-	EnableHolePunching Flag
+	EnableHolePunching Flag `json:",omitempty"`
 
 	// Transports contains flags to enable/disable libp2p transports.
 	Transports Transports

--- a/swarm.go
+++ b/swarm.go
@@ -35,6 +35,9 @@ type SwarmConfig struct {
 	// When enabled, node will provide a limited relay service to other peers.
 	RelayService RelayService
 
+	// EnableHolePunching enables the hole punching service.
+	EnableHolePunching Flag
+
 	// Transports contains flags to enable/disable libp2p transports.
 	Transports Transports
 


### PR DESCRIPTION
The tricky part of this will be the logic how we enable this:

- For this release, we enable hole punching if AutoRelay is enabled.
- For the next release (when the network has an army of relay nodes), we enabled this by default.