### PR TITLE
feat: omitempty Swarm.EnableRelayHop for circuit v1 migration

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -24,7 +24,7 @@ type SwarmConfig struct {
 	//
 	// Deprecated: The circuit v1 protocol is deprecated.
 	// Use `Swarm.RelayService` to configure the circuit v2 relay.
-	EnableRelayHop bool
+	EnableRelayHop bool `json:",omitempty"`
 
 	// EnableAutoRelay enables the "auto relay user" feature.
 	// Node will find and use advertised public relays when it determines that

--- a/swarm.go
+++ b/swarm.go
@@ -19,6 +19,13 @@ type SwarmConfig struct {
 	// `Swarm.Transports.Relay` if specified.
 	DisableRelay bool `json:",omitempty"`
 
+	// EnableRelayHop makes this node act as a public relay, relaying
+	// traffic between other nodes.
+	//
+	// Deprecated: The circuit v1 protocol is deprecated.
+	// Use `Swarm.RelayService` to configure the circuit v2 relay.
+	EnableRelayHop bool
+
 	// EnableAutoRelay enables the "auto relay user" feature.
 	// Node will find and use advertised public relays when it determines that
 	// it's not reachable from the public internet.

--- a/swarm.go
+++ b/swarm.go
@@ -19,8 +19,7 @@ type SwarmConfig struct {
 	// `Swarm.Transports.Relay` if specified.
 	DisableRelay bool `json:",omitempty"`
 
-	// EnableRelayHop makes this node act as a public relay, relaying
-	// traffic between other nodes.
+	// EnableRelayHop makes this node act as a public relay v1
 	//
 	// Deprecated: The circuit v1 protocol is deprecated.
 	// Use `Swarm.RelayService` to configure the circuit v2 relay.


### PR DESCRIPTION
> Needed for https://github.com/ipfs/go-ipfs/pull/8559

Unfortunately, semver will probably force us to release this as v0.18.0.

