### PR TITLE
chore: omitempty Experimental.ShardingEnabled

### DIFF
--- a/experiments.go
+++ b/experiments.go
@@ -3,7 +3,7 @@ package config
 type Experiments struct {
 	FilestoreEnabled     bool
 	UrlstoreEnabled      bool
-	ShardingEnabled      bool
+	ShardingEnabled      bool `json:",omitempty"` // deprecated by autosharding: https://github.com/ipfs/go-ipfs/pull/8527
 	GraphsyncEnabled     bool
 	Libp2pStreamMounting bool
 	P2pHttpProxy         bool


### PR DESCRIPTION
Given that we switch to autosharding setup in https://github.com/ipfs/go-ipfs/pull/8527,  we should deprecate this flag, making it optional in JSON. 