### PR TITLE
feat: Add DNS.MaxCacheTTL for DNS-over-HTTPS resolvers

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -12,4 +12,6 @@ type DNS struct {
 	// - Custom resolver for ENS:          `eth.` → `https://eth.link/dns-query`
 	// - Override the default OS resolver: `.`    → `https://doh.applied-privacy.net/query`
 	Resolvers map[string]string
+	// MaxCacheTTL is the maximum duration DNS entries are valid in the cache.
+	MaxCacheTTL *OptionalDuration `json:",omitempty"`
 }


### PR DESCRIPTION
* Add an optional parameter to set a maximum TTL for DNS-over-HTTPS resolver

This is going to be used to expose `WithMaxCacheTTL` option of go-doh-resolver, which release is tracked in https://github.com/libp2p/go-doh-resolver/issues/15.