### PR TITLE
feat(plugins): change from interface{} to json.RawMessage

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"encoding/json"
+)
+
 type Plugins struct {
 	Plugins map[string]Plugin
 	// TODO: Loader Path? Leaving that out for now due to security concerns.
@@ -7,5 +11,5 @@ type Plugins struct {
 
 type Plugin struct {
 	Disabled bool
-	Config   interface{}
+	Config   json.RawMessage
 }


### PR DESCRIPTION
This change is for let users parse it themselves.
By default, the `interface{}` used by plugin will convert the content to map.
If the plugin needs to determine the value itself, it is better to let the plugin parse the Config itself.
