### PR TITLE
Ipns.ReproviderDuration for PubSub GC

### DIFF
--- a/ipns.go
+++ b/ipns.go
@@ -4,7 +4,8 @@ type Ipns struct {
 	RepublishPeriod string
 	RecordLifetime  string
 
-	ResolveCacheSize int
+	ResolveCacheSize   int
+	ReproviderDuration *OptionalDuration `json:",omitempty"`
 
 	// Enable namesys pubsub (--enable-namesys-pubsub)
 	UsePubsub Flag `json:",omitempty"`


### PR DESCRIPTION
`go-ipfs-config` part of libp2p/go-libp2p-pubsub-router#92, which fixes [#8586](https://github.com/ipfs/go-ipfs/issues/8586).